### PR TITLE
Fix the File Open dialog that does not show

### DIFF
--- a/cviewer/action/load_cff.py
+++ b/cviewer/action/load_cff.py
@@ -55,7 +55,7 @@ class OpenFile(Action):
             cfile = self.window.application.get_service('cviewer.plugins.cff2.cfile.CFile')
             exec_as_funct = False
 
-        wildcard = "All files (*.*)|*.*" \
+        wildcard = "All files (*.*)|*.*|" \
                    "Nifti-1 (*.nii.gz)|*.nii.gz|" \
                    "Gifti (*.gii)|*.gii|" \
                    "TrackVis tracks (*.trk)|*.trk|" \


### PR DESCRIPTION
Here, clicking on open file doesn't show any dialog. The console shows:

Traceback (most recent call last):
  File
"/usr/lib/python2.7/dist-packages/pyface/ui/wx/action/action_item.py",
line 260, in _on_menu
    self.controller.perform(action, action_event)
  File
"/usr/lib/python2.7/dist-packages/pyface/workbench/action/action_controller.py",
line 35, in perform
    return action.perform(event)
  File "/usr/lib/pymodules/python2.7/cviewer/action/load_cff.py", line
73, in perform
    if dlg.open() == OK:
  File "/usr/lib/python2.7/dist-packages/pyface/i_dialog.py", line 118,
in open
    self._create()
  File "/usr/lib/python2.7/dist-packages/pyface/i_dialog.py", line 137,
in _create
    super(MDialog, self)._create()
  File "/usr/lib/python2.7/dist-packages/pyface/i_window.py", line 205,
in _create
    super(MWindow, self)._create()
  File "/usr/lib/python2.7/dist-packages/pyface/i_widget.py", line 67,
in _create
    self.control = self._create_control(self.parent)
  File "/usr/lib/python2.7/dist-packages/pyface/ui/wx/file_dialog.py",
line 117, in _create_control
    wildcard=self.wildcard.rstrip('|'))
  File "/usr/lib/python2.7/dist-packages/wx-3.0-gtk2/wx/_windows.py",
line 3139, in __init__
    _windows_.FileDialog_swiginit(self,_windows_.new_FileDialog(_args,
*_kwargs))
wx._core.PyAssertionError: C++ assertion "Assert failure" failed at
../src/common/filefn.cpp(1685) in wxParseCommonDialogsFilter(): missing
'|' in the wildcard string!

That commit fixes that.
